### PR TITLE
fix mktemp error

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,7 +12,7 @@ of_version=v0.9.2
 of_platform=osx
 of_package_name=of_${of_version}_${of_platform}_release
 of_url=http://openframeworks.cc/versions/${of_version}/${of_package_name}.zip
-working_dir=`mktemp -d`
+working_dir=`mktemp -d -t tmp`
 script_dir=`dirname $0`
 
 # function


### PR DESCRIPTION
Following command is error. OSX 10.10 Yosemite

```
sh ./scripts/setup.sh
```

Error message:

```
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix
```
